### PR TITLE
Add buildx support in github actions to release arm64 and armv7 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u ${USERNAME} -p ${PASSWORD}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./3.10.1
+          file: ./3.10.1/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: |
+            ${USERNAME}/iperf-server-v3.10.1:latest


### PR DESCRIPTION
Hi

**Package Owner:** Subham Kumar

PR change Details:

**Patch Details:** Following files has been changed:

.github/workflows/main.yml: Added github actions to build and push the images for latest versions to dockerhub using buildx.

**PR Description: Here is my commit message :**
Add arm64 and armv7 support using buildx.

**PR Description:**

The following file has been created and modified:

Added .github/workflows/main.yml to build and push the images for latest versions to dockerhub using buildx.

**Signed-off-by:** odidev odidev@puresoftware.com

Reviewer: Pruthvi Teja Reddy
Thanks
Subham Kumar